### PR TITLE
Allow passing the DSN by using `doctine.dbal.options.dsn` for symfony projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Once the DSN is configured we will have to configure the connection in the follo
 $connection = \Doctrine\DBAL\DriverManager::getConnection(
     [
         'driverClass' => \ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver::class,
-        'dsn' => 'name of the created dsn',
+        'driverOptions' => [
+            'dsn' => 'name of the created dsn',
+        ],
     ]
 );
 ```
@@ -47,8 +49,8 @@ configure the driver as follows:
 $connection = \Doctrine\DBAL\DriverManager::getConnection(
     [
         'driverClass' => \ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver::class,
-        'dsn' => 'name of the created dsn',
         'driverOptions' => [
+            'dsn' => 'name of the created dsn',
             'charset' => 'UTF-8',
         ],
     ]


### PR DESCRIPTION
The README.MD describes to pass the `dns` as part of the `$params` array:

```php
$connection = \Doctrine\DBAL\DriverManager::getConnection(
    [
        'driverClass' => \ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver::class,
        'dsn' => 'name of the created dsn',
    ]
);
```

I tried to set the DSN by using the `config/packages/doctrine.yaml` of a symfony project:

**config/packages/doctrine.yaml**
```yaml
doctrine:
    dbal:
        driver_class: '\ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver'
        dsn: '%env(resolve:ODBC_DSN)%'
```

The above configuration throws the following error because `doctrine.dbal` doesn't support custom attributes (like `dsn`):

> Unrecognized option "dsn" under "doctrine.dbal.connections.default". Available options are "MultipleActiveResultSets", "application_name", "auto_commit", "charset", "connectstring", "dbname", "default_dbname", "default_table_options", "driver", "driver_class", "host", "instancename", "keep_slave", "logging", "mapping_types", "memory", "options", "password", "path", "persistent", "platform_service", "pooled", "port", "profiling", "profiling_collect_backtrace", "profiling_collect_schema_errors", "protocol", "schema_filter", "server", "server_version", "service", "servicename", "sessionMode", "shard_choser", "shard_choser_service", "shard_manager_class", "shards", "slaves", "sslcert", "sslcrl", "sslkey", "sslmode", "sslrootcert", "unix_socket", "url", "use_savepoints", "user", "wrapper_class".

Passing the `dsn` attribute as part of `doctine.dbal.options` is working:

**config/packages/doctrine.yaml**
```yaml
doctrine:
    dbal:
        driver_class: '\ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver'
        options:
            dsn: '%env(resolve:ODBC_DSN)%'
```

**.env**
```
ODBC_DSN="DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};DBQ=C:\\xampp\\htdocs\\MyDatabase.mdb;"
```

This requires the `ZoiloMora\Doctrine\DBAL\Driver\MicrosoftAccess\Driver`'s constructor to also check the `$driverOptions` for a DSN. This change is done in this pull request.